### PR TITLE
add new "Suggested for you" filter

### DIFF
--- a/fb.txt
+++ b/fb.txt
@@ -22,6 +22,7 @@ facebook.com##div[data-pagelet^="FeedUnit_"]:has-text(Keep Your Page Up to Date)
 facebook.com##div[data-pagelet^="FeedUnit_"]:has-text(Try an ad)
 facebook.com###watch_feed a:has(svg):xpath(../../../../..):has(a[aria-label=label]:has-text(S):has-text(p):has-text(o))
 facebook.com###watch_feed a:has(svg):xpath(../../../../..):has(a[aria-label=Sponsored])
+facebook.com##:xpath(//div[@role='article' and .//span[.='Suggested for you']])
 !
 ! Promotion call-to-actions
 !


### PR DESCRIPTION
looks like they removed the `[data-pagelet^=FeedUnit_]` we were using for most of the rules

had to use xpath because they're using a trick with `before` and `after` to prevent `has-text` from working (i think)

![image](https://user-images.githubusercontent.com/57028336/150615100-541867d5-0a32-4fa5-9fb2-7adde9b30ca9.png)
![image](https://user-images.githubusercontent.com/57028336/150615152-a2c9c48e-e244-4aae-acd8-47a8f3728545.png)
